### PR TITLE
Add API usage examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,22 @@ pytest
 ```bash
 uvicorn rag_service.main:app --reload
 ```
+
+## API Usage
+
+### Index a repository
+
+```bash
+curl -X POST http://localhost:8000/v1/index \
+    -H "Content-Type: application/json" \
+    -d '{"root_path": ".", "clean": false}'
+```
+
+### Query indexed data
+
+```bash
+curl -X POST http://localhost:8000/v1/query \
+    -H "Content-Type: application/json" \
+    -d '{"q": "example question", "top_k": 3}'
+```
+


### PR DESCRIPTION
## Summary
- document index and query endpoints in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af5472fc148320954bb96256658c7d