### PR TITLE
Use AST code splitter for source indexing

### DIFF
--- a/rag_service/indexer.py
+++ b/rag_service/indexer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from llama_index.core import Document, StorageContext, VectorStoreIndex
-from llama_index.core.node_parser import SentenceSplitter
+from llama_index.core.node_parser import CodeSplitter
 from qdrant_client import QdrantClient
 
 from .config import AppConfig
@@ -83,9 +83,11 @@ class PathIndexer:
                 "lang": lang,
             },
         )
-        splitter = SentenceSplitter(
-            chunk_size=self.cfg.ast.max_chars,
-            chunk_overlap=self.cfg.ast.chunk_overlap,
+        splitter = CodeSplitter(
+            language=lang,
+            chunk_lines=self.cfg.ast.chunk_lines,
+            chunk_lines_overlap=self.cfg.ast.chunk_overlap,
+            max_chars=self.cfg.ast.max_chars,
         )
         nodes = splitter.get_nodes_from_documents([doc])
         for n in nodes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ httpx==0.27.0
 pydantic==2.11.5
 orjson==3.10.4
 pytest==8.2.2
+tree_sitter==0.25.1
+tree_sitter_language_pack==0.9.0


### PR DESCRIPTION
## Summary
- use `CodeSplitter` with ASTConfig to chunk code
- add tree-sitter dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5ff01a588320a95389400e7a58ee