### PR TITLE
Describe files from their content

### DIFF
--- a/prompts/file_card.md
+++ b/prompts/file_card.md
@@ -1,2 +1,4 @@
-You are an assistant creating brief descriptions of code files.
-Summarize the purpose of the file and list major classes or functions.
+You are an assistant creating short descriptions of source code files.
+Describe in plain language what the code in the file does.
+Do not list classes, functions, interfaces, or other language constructs.
+Keep the description concise yet cover all functionality of the file.

--- a/rag_service/indexer.py
+++ b/rag_service/indexer.py
@@ -100,10 +100,11 @@ class PathIndexer:
         VectorStoreIndex(nodes, storage_context=StorageContext.from_defaults(vector_store=self.code_vs))
         return len(nodes)
 
-    def _generate_file_card(self, file_path: Path) -> str:
+    def _generate_file_card(self, file_path: Path, file_text: str) -> str:
         """Generate a textual description for the file."""
 
-        prompt = Path(self.cfg.prompts.file_card_md).read_text() + f"\nFile: {file_path.name}\n"
+        prompt = Path(self.cfg.prompts.file_card_md).read_text()
+        prompt += f"\nFilename: {file_path.name}\n```{file_text}```\n"
         try:
             return self.llama.llm().complete(prompt).text
         except Exception:
@@ -131,7 +132,7 @@ class PathIndexer:
         text, file_hash = self._read_file(file_path)
         nodes = self._create_nodes(text, file_path, file_hash)
         stats.code_nodes_upserted += self._upsert_code_nodes(nodes)
-        card_text = self._generate_file_card(file_path)
+        card_text = self._generate_file_card(file_path, text)
         self._upsert_file_card(file_path, file_hash, card_text)
         stats.file_cards_upserted += 1
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+from typing import Any
 
 from qdrant_client import QdrantClient
 from llama_index.core import Settings
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.llms import MockLLM
+from pydantic import PrivateAttr
 
 from rag_service.config import AppConfig
 from rag_service.indexer import index_path
@@ -12,16 +14,26 @@ from rag_service.retriever import build_query_engine
 
 
 class DummyEmbedding(BaseEmbedding):
-    def _get_text_embedding(self, text: str):
+    """Embedding model returning zeros for every request."""
+
+    def _get_text_embedding(self, text: str) -> list[float]:
+        """Return a dummy embedding for text."""
+
         return [0.0, 0.0, 0.0]
 
-    async def _aget_text_embedding(self, text: str):
+    async def _aget_text_embedding(self, text: str) -> list[float]:
+        """Asynchronously return a dummy embedding for text."""
+
         return self._get_text_embedding(text)
 
-    def _get_query_embedding(self, text: str):
+    def _get_query_embedding(self, text: str) -> list[float]:
+        """Return a dummy embedding for a query."""
+
         return [0.0, 0.0, 0.0]
 
-    async def _aget_query_embedding(self, text: str):
+    async def _aget_query_embedding(self, text: str) -> list[float]:
+        """Asynchronously return a dummy embedding for a query."""
+
         return self._get_query_embedding(text)
 
 
@@ -46,6 +58,47 @@ def test_index_and_query(tmp_path):
     qe = build_query_engine(cfg, qdrant, llama)
     res = qe.retrieve("Foo")
     assert res
+
+
+class CaptureLLM(MockLLM):
+    """LLM that stores the last prompt."""
+
+    _last_prompt: str = PrivateAttr("")
+
+    def complete(self, prompt: str, **kwargs: Any) -> Any:
+        """Record the prompt and return a mock completion."""
+
+        self._last_prompt = prompt
+        return super().complete(prompt, **kwargs)
+
+    @property
+    def last_prompt(self) -> str:
+        """Return the last recorded prompt."""
+
+        return self._last_prompt
+
+
+def test_file_text_passed_to_llm(tmp_path):
+    """Ensure file text, not path, is sent to the LLM."""
+
+    src = tmp_path / "src"
+    src.mkdir()
+    code = "class Foo { fun bar() {} }"
+    (src / "Test.kt").write_text(code)
+
+    cfg = AppConfig.load(Path("config.json"))
+    qdrant = QdrantClient(location=":memory:")
+    llama = LlamaIndexFacade(cfg, qdrant, initialize=False)
+
+    original_llm = Settings.llm
+    capture_llm = CaptureLLM()
+    Settings.llm = capture_llm
+    try:
+        index_path(src, cfg, qdrant, llama)
+    finally:
+        Settings.llm = original_llm
+
+    assert code in capture_llm.last_prompt
 
 
 def test_scan_respects_blacklist(tmp_path):


### PR DESCRIPTION
## Summary
- pass file text to LLM when generating file cards
- refine file card prompt to require concise human-focused description without listing language constructs
- add regression test ensuring file text is sent to the LLM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af64ab6a7c8320b558fadd23a4e95f