### PR TITLE
Include line ranges in interface output

### DIFF
--- a/rag_service/interface_extractor.py
+++ b/rag_service/interface_extractor.py
@@ -40,9 +40,10 @@ def _is_public(name: str, signature: str) -> bool:
 def extract_public_interfaces(file_path: Path, lang: str | None) -> List[str]:
     """Return a list of public interfaces found in ``file_path``.
 
-    The function uses ``tree-sitter`` to parse the file using the provided
-    language identifier. If the language is unsupported or parsing fails,
-    an empty list is returned.
+    Each interface signature is suffixed with ``[first_line:last_line]`` to
+    indicate its location in the file. The function uses ``tree-sitter`` to
+    parse the file using the provided language identifier. If the language is
+    unsupported or parsing fails, an empty list is returned.
     """
 
     try:
@@ -61,7 +62,9 @@ def extract_public_interfaces(file_path: Path, lang: str | None) -> List[str]:
                 name = source[name_node.start_byte : name_node.end_byte].decode("utf-8", errors="ignore")
                 sig = _signature_from_node(node, source)
                 if _is_public(name, sig):
-                    signatures.append(sig)
+                    start_line = node.start_point[0] + 1
+                    end_line = node.end_point[0] + 1
+                    signatures.append(f"{sig} [{start_line}:{end_line}]")
         for child in node.children:
             visit(child)
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -15,9 +15,9 @@ def test_extract_public_interfaces(tmp_path):
     file_path = tmp_path / "sample.py"
     file_path.write_text(src)
     interfaces = extract_public_interfaces(file_path, "python")
-    assert "class Example:" in interfaces
-    assert "def public(self):" in interfaces
-    assert "def standalone():" in interfaces
+    assert "class Example: [1:5]" in interfaces
+    assert "def public(self): [2:3]" in interfaces
+    assert "def standalone(): [7:8]" in interfaces
     assert all("_private" not in s for s in interfaces)
     assert all("_helper" not in s for s in interfaces)
 
@@ -52,4 +52,4 @@ def test_query_endpoint_interfaces(tmp_path, monkeypatch):
     main.LLAMA = object()
 
     resp = main.query_endpoint(main.QueryRequest(q="test", interfaces=True))
-    assert resp["items"][0]["interfaces"] == ["def foo():"]
+    assert resp["items"][0]["interfaces"] == ["def foo(): [1:2]"]


### PR DESCRIPTION
## Summary
- Append `[first_line:last_line]` to each extracted interface signature
- Describe returned line ranges in interface extractor docstring
- Update interface tests to expect line range annotations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7b9a38948320b3b4d53c95c4e55c