### PR TITLE
Expand interface extraction coverage

### DIFF
--- a/rag_service/interface_extractor.py
+++ b/rag_service/interface_extractor.py
@@ -10,30 +10,68 @@ from tree_sitter_language_pack import get_parser
 PUBLIC_NODE_TYPES = {
     "function_definition",
     "function_declaration",
+    "function_item",
     "method_definition",
+    "method_declaration",
+    "method_signature",
     "class_definition",
     "class_declaration",
     "interface_declaration",
+    "object_declaration",
     "struct_declaration",
+    "struct_item",
     "enum_declaration",
+    "enum_item",
+    "type_declaration",
+    "lexical_declaration",
+    "variable_declaration",
+}
+
+NAME_NODE_TYPES = {
+    "identifier",
+    "type_identifier",
+    "simple_identifier",
 }
 
 
 def _signature_from_node(node: Node, source: bytes) -> str:
     line = source[node.start_byte : node.end_byte].splitlines()[0]
     line = line.decode("utf-8", errors="ignore").strip()
-    for sep in (":", "{"):
+    for sep in ("=", "{"):
         if sep in line:
-            line = f"{line.split(sep)[0]}{sep}"
-            break
+            return f"{line.split(sep)[0]}{sep}"
+    if ":" in line:
+        idx = line.rfind(":")
+        if idx > line.rfind(")") and idx > line.rfind("}"):
+            return f"{line[:idx + 1]}"
     return line
 
 
-def _is_public(name: str, signature: str) -> bool:
-    if name.startswith("_"):
+def _is_public(name: str, signature: str, node: Node, lang: str) -> bool:
+    """Determine if the given ``name`` and ``signature`` are public."""
+
+    if name.startswith("_") or name.startswith("#"):
         return False
-    if "private" in signature:
+    lower = signature.lower()
+    if any(mod in lower for mod in ("private", "protected", "internal")):
         return False
+    if lang == "java":
+        if "public" not in lower:
+            ancestor = node.parent
+            found_interface = False
+            while ancestor is not None:
+                if ancestor.type == "interface_declaration":
+                    found_interface = True
+                    break
+                ancestor = ancestor.parent
+            if not found_interface:
+                return False
+    if lang == "rust":
+        if not lower.startswith("pub"):
+            return False
+    if lang == "go":
+        if name[:1].islower():
+            return False
     return True
 
 
@@ -52,16 +90,29 @@ def extract_public_interfaces(file_path: Path, lang: str | None) -> List[str]:
         return []
     source = file_path.read_bytes()
     tree = parser.parse(source)
+    if tree.root_node.has_error:
+        return []
 
     signatures: List[str] = []
 
     def visit(node: Node) -> None:
         if node.type in PUBLIC_NODE_TYPES:
             name_node = node.child_by_field_name("name")
-            if name_node:
+            if name_node is None:
+                def find_name(n: Node) -> Node | None:
+                    for child in n.children:
+                        if child.type in NAME_NODE_TYPES:
+                            return child
+                        found = find_name(child)
+                        if found is not None:
+                            return found
+                    return None
+
+                name_node = find_name(node)
+            if name_node is not None:
                 name = source[name_node.start_byte : name_node.end_byte].decode("utf-8", errors="ignore")
                 sig = _signature_from_node(node, source)
-                if _is_public(name, sig):
+                if _is_public(name, sig, node, lang or ""):
                     start_line = node.start_point[0] + 1
                     end_line = node.end_point[0] + 1
                     signatures.append(f"{sig} [{start_line}:{end_line}]")

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,46 +1,263 @@
 from pathlib import Path
 
+import pytest
 from rag_service.interface_extractor import extract_public_interfaces
 from rag_service import main
+from pytest import MonkeyPatch
 
 
-def test_extract_public_interfaces(tmp_path):
-    src = (
-        "class Example:\n"
-        "    def public(self):\n        pass\n"
-        "    def _private(self):\n        pass\n\n"
-        "def standalone():\n    pass\n"
-        "def _helper():\n    pass\n"
-    )
-    file_path = tmp_path / "sample.py"
-    file_path.write_text(src)
-    interfaces = extract_public_interfaces(file_path, "python")
-    assert "class Example: [1:5]" in interfaces
-    assert "def public(self): [2:3]" in interfaces
-    assert "def standalone(): [7:8]" in interfaces
-    assert all("_private" not in s for s in interfaces)
-    assert all("_helper" not in s for s in interfaces)
+LANG_CASES = {
+    "python": {
+        "ext": "py",
+        "code": (
+            "class Example:\n"
+            "    def public(self):\n        pass\n"
+            "    def _private(self):\n        pass\n\n"
+            "def standalone():\n    pass\n"
+            "def _helper():\n    pass\n"
+        ),
+        "expected": [
+            "class Example: [1:5]",
+            "def public(self): [2:3]",
+            "def standalone(): [7:8]",
+        ],
+        "unexpected": ["_private", "_helper"],
+    },
+    "kotlin": {
+        "ext": "kt",
+        "code": (
+            "interface Sample<T> {\n"
+            "    fun ifaceFun(t: T)\n"
+            "}\n"
+            "class Example<T> {\n"
+            "    fun publicFun(t: T) {}\n"
+            "    protected fun protectedFun() {}\n"
+            "    internal fun internalFun() {}\n"
+            "}\n"
+            "object Single {\n"
+            "    fun objectFun() {}\n"
+            "    private fun hidden() {}\n"
+            "}\n"
+            "fun topLevel() {}\n"
+        ),
+        "expected": [
+            "interface Sample<T> { [1:3]",
+            "fun ifaceFun(t: T) [2:2]",
+            "class Example<T> { [4:8]",
+            "fun publicFun(t: T) { [5:5]",
+            "object Single { [9:12]",
+            "fun objectFun() { [10:10]",
+            "fun topLevel() { [13:13]",
+        ],
+        "unexpected": ["protectedFun", "internalFun", "hidden"],
+    },
+    "java": {
+        "ext": "java",
+        "code": (
+            "public interface Sample<T> {\n"
+            "    T interfaceMethod(T param);\n"
+            "    private void hidden();\n"
+            "}\n"
+            "public class Example<T> {\n"
+            "    public void publicMethod() {}\n"
+            "    protected void protectedMethod() {}\n"
+            "    void packagePrivateMethod() {}\n"
+            "    private void privateMethod() {}\n"
+            "    public class Inner {\n"
+            "        public void inner() {}\n"
+            "        private void innerHidden() {}\n"
+            "    }\n"
+            "}\n"
+        ),
+        "expected": [
+            "public interface Sample<T> { [1:4]",
+            "T interfaceMethod(T param); [2:2]",
+            "public class Example<T> { [5:14]",
+            "public void publicMethod() { [6:6]",
+            "public class Inner { [10:13]",
+            "public void inner() { [11:11]",
+        ],
+        "unexpected": [
+            "hidden",
+            "protectedMethod",
+            "packagePrivateMethod",
+            "privateMethod",
+            "innerHidden",
+        ],
+    },
+    "javascript": {
+        "ext": "js",
+        "code": (
+            "export default function defaultFunc() {}\n"
+            "export function namedFunc() {}\n"
+            "export const arrow = () => {}\n"
+            "export const obj = {\n"
+            "  method() {}\n"
+            "}\n"
+            "class Example {\n"
+            "  publicMethod() {}\n"
+            "  #privateMethod() {}\n"
+            "}\n"
+            "function topLevel() {}\n"
+            "function _hidden() {}\n"
+        ),
+        "expected": [
+            "function defaultFunc() { [1:1]",
+            "function namedFunc() { [2:2]",
+            "const arrow = [3:3]",
+            "const obj = [4:6]",
+            "method() { [5:5]",
+            "class Example { [7:10]",
+            "publicMethod() { [8:8]",
+            "function topLevel() { [11:11]",
+        ],
+        "unexpected": ["#privateMethod", "_hidden"],
+    },
+    "typescript": {
+        "ext": "ts",
+        "code": (
+            "export interface Sample<T> {\n"
+            "  ifaceMethod(param: T): T;\n"
+            "}\n"
+            "export class Example<T> {\n"
+            "  public publicMethod(): T { return; }\n"
+            "  protected protectedMethod(): void {}\n"
+            "  private privateMethod(): void {}\n"
+            "  #privateMethod(): void {}\n"
+            "}\n"
+            "export function topLevel<T>(arg: T): T { return arg; }\n"
+            "export const arrow = <T>(arg: T): T => arg;\n"
+            "export const obj = {\n"
+            "  method<T>(arg: T): T { return arg; }\n"
+            "}\n"
+            "function _hidden(): void {}\n"
+        ),
+        "expected": [
+            "interface Sample<T> { [1:3]",
+            "ifaceMethod(param: T): [2:2]",
+            "class Example<T> { [4:9]",
+            "public publicMethod(): T { [5:5]",
+            "function topLevel<T>(arg: T): T { [10:10]",
+            "const arrow = [11:11]",
+            "const obj = [12:14]",
+            "method<T>(arg: T): T { [13:13]",
+        ],
+        "unexpected": [
+            "protectedMethod",
+            "privateMethod",
+            "#privateMethod",
+            "_hidden",
+        ],
+    },
+    "rust": {
+        "ext": "rs",
+        "code": (
+            "pub struct PublicStruct {\n"
+            "    pub field: i32,\n"
+            "}\n"
+            "struct PrivateStruct {\n"
+            "    field: i32,\n"
+            "}\n"
+            "pub enum PublicEnum {\n"
+            "    A,\n"
+            "    B,\n"
+            "}\n"
+            "enum PrivateEnum {\n"
+            "    A,\n"
+            "}\n"
+            "impl PublicStruct {\n"
+            "    pub fn new() -> Self {\n"
+            "        Self { field: 0 }\n"
+            "    }\n"
+            "    fn hidden() {}\n"
+            "}\n"
+        ),
+        "expected": [
+            "pub struct PublicStruct { [1:3]",
+            "pub enum PublicEnum { [7:10]",
+            "pub fn new() -> Self { [15:17]",
+        ],
+        "unexpected": ["PrivateStruct", "PrivateEnum", "hidden"],
+    },
+    "go": {
+        "ext": "go",
+        "code": (
+            "package sample\n\n"
+            "type PublicStruct struct {\n"
+            "    Field int\n"
+            "}\n\n"
+            "type privateStruct struct {\n"
+            "    field int\n"
+            "}\n\n"
+            "func PublicFunc() {}\n\n"
+            "func privateFunc() {}\n"
+        ),
+        "expected": [
+            "type PublicStruct struct { [3:5]",
+            "func PublicFunc() { [11:11]",
+        ],
+        "unexpected": ["privateStruct", "privateFunc"],
+    },
+}
 
 
-def test_query_endpoint_interfaces(tmp_path, monkeypatch):
+@pytest.mark.parametrize("lang", LANG_CASES)
+def test_extract_public_interfaces_languages(tmp_path: Path, lang: str) -> None:
+    """It extracts public interfaces for supported languages."""
+
+    case = LANG_CASES[lang]
+    file_path = tmp_path / f"sample.{case['ext']}"
+    file_path.write_text(case["code"])
+    interfaces = extract_public_interfaces(file_path, lang)
+    for expected in case["expected"]:
+        assert expected in interfaces
+    for name in case["unexpected"]:
+        assert all(name not in s for s in interfaces)
+
+
+def test_extract_public_interfaces_invalid_language(tmp_path: Path) -> None:
+    """Unsupported language yields no interfaces."""
+
+    fp = tmp_path / "sample.foo"
+    fp.write_text("func main() {}")
+    assert extract_public_interfaces(fp, "foo") == []
+
+
+def test_extract_public_interfaces_syntax_error(tmp_path: Path) -> None:
+    """Syntax errors result in empty interface lists."""
+
+    fp = tmp_path / "broken.py"
+    fp.write_text("def broken(:\n    pass")
+    assert extract_public_interfaces(fp, "python") == []
+
+
+def test_query_endpoint_interfaces(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Query endpoint returns interface data when requested."""
+
     code = "def foo():\n    pass\n"
     fp = tmp_path / "test.py"
     fp.write_text(code)
 
     class Node:
-        def __init__(self, metadata):
+        """Mock node mimicking a vector store result."""
+
+        def __init__(self, metadata: dict) -> None:
             self.metadata = metadata
 
-        def get_content(self):
+        def get_content(self) -> str:
             return code
 
     class Result:
-        def __init__(self, metadata):
+        """Container for a mocked node result."""
+
+        def __init__(self, metadata: dict) -> None:
             self.node = Node(metadata)
             self.score = 1.0
 
     class Retriever:
-        def retrieve(self, q):
+        """Simple retriever returning a fixed result."""
+
+        def retrieve(self, q: str) -> list[Result]:
             return [Result({"file_path": str(fp), "lang": "python"})]
 
     def fake_build_query_engine(cfg, qdrant, llama):


### PR DESCRIPTION
## Summary
- broaden supported syntax nodes and access modifier rules for interface extraction across languages
- add cross-language tests for generics, nested declarations, module exports, structs, enums, and negative cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b01a919bec8320be4b8b611d090b28