### PR TITLE
Implement configurable retrieval fusion

### DIFF
--- a/config.json
+++ b/config.json
@@ -57,7 +57,10 @@
       "code_nodes_top_k": 6,
       "file_cards_top_k": 4,
       "dir_cards_top_k": 2,
-      "fusion_mode": "relative_score"
+      "fusion_mode": "relative_score",
+      "code_weight": 1.0,
+      "file_weight": 1.0,
+      "rrf_k": 60
     }
   },
   "http": {

--- a/rag_service/config.py
+++ b/rag_service/config.py
@@ -55,6 +55,9 @@ class RetrievalConfig(BaseModel):
     file_cards_top_k: int = 4
     dir_cards_top_k: int = 2
     fusion_mode: str = "relative_score"
+    code_weight: float = 1.0
+    file_weight: float = 1.0
+    rrf_k: int = 60
 
 
 class LlamaIndexConfig(BaseModel):

--- a/rag_service/retriever.py
+++ b/rag_service/retriever.py
@@ -1,13 +1,55 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Sequence
 
 from llama_index.core import VectorStoreIndex
+from llama_index.core.schema import NodeWithScore
 from qdrant_client import QdrantClient
 
 from .config import AppConfig
 from .llama_facade import LlamaIndexFacade
 
+
+def _relative_rescore(nodes: Sequence[NodeWithScore], weight: float) -> List[NodeWithScore]:
+    """Rescore nodes relative to the top score and apply ``weight``."""
+
+    if not nodes:
+        return []
+    top = nodes[0].score or 1.0
+    for node in nodes:
+        node.score = weight * (node.score / top)
+    return list(nodes)
+
+
+def _rrf_rescore(
+    nodes: Sequence[NodeWithScore], weight: float, k: int
+) -> List[NodeWithScore]:
+    """Apply reciprocal rank fusion to ``nodes`` with ``weight``."""
+
+    rescored: List[NodeWithScore] = []
+    for idx, node in enumerate(nodes, start=1):
+        node.score = weight / (k + idx)
+        rescored.append(node)
+    return rescored
+
+
+def fuse_results(
+    code_nodes: Sequence[NodeWithScore],
+    file_nodes: Sequence[NodeWithScore],
+    mode: str,
+    code_weight: float,
+    file_weight: float,
+    rrf_k: int,
+) -> List[NodeWithScore]:
+    """Fuse code and file retrieval results according to ``mode``."""
+
+    if mode == "rrf":
+        rescored = _rrf_rescore(code_nodes, code_weight, rrf_k)
+        rescored += _rrf_rescore(file_nodes, file_weight, rrf_k)
+    else:
+        rescored = _relative_rescore(code_nodes, code_weight)
+        rescored += _relative_rescore(file_nodes, file_weight)
+    return sorted(rescored, key=lambda n: n.score, reverse=True)
 
 def build_query_engine(cfg: AppConfig, qdrant: QdrantClient, llama: LlamaIndexFacade | None = None):
     """Build a simple retriever combining code and file card indexes."""
@@ -23,8 +65,17 @@ def build_query_engine(cfg: AppConfig, qdrant: QdrantClient, llama: LlamaIndexFa
         similarity_top_k=cfg.llamaindex.retrieval.file_cards_top_k
     )
 
+    fusion_mode = cfg.llamaindex.retrieval.fusion_mode
+    code_weight = getattr(cfg.llamaindex.retrieval, "code_weight", 1.0)
+    file_weight = getattr(cfg.llamaindex.retrieval, "file_weight", 1.0)
+    rrf_k = getattr(cfg.llamaindex.retrieval, "rrf_k", 60)
+
     class SimpleRetriever:
         def retrieve(self, query: str):
-            return code_ret.retrieve(query) + file_ret.retrieve(query)
+            code_nodes = code_ret.retrieve(query)
+            file_nodes = file_ret.retrieve(query)
+            return fuse_results(
+                code_nodes, file_nodes, fusion_mode, code_weight, file_weight, rrf_k
+            )
 
     return SimpleRetriever()

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,31 @@
+from llama_index.core.schema import NodeWithScore, TextNode
+
+from rag_service.retriever import fuse_results
+
+
+def _node(node_id: str, score: float) -> NodeWithScore:
+    """Create a ``NodeWithScore`` for testing."""
+
+    return NodeWithScore(node=TextNode(id_=node_id, text=""), score=score)
+
+
+def test_relative_score_fusion_sorting() -> None:
+    """Relative score fusion should respect weights and sort nodes."""
+
+    code = [_node("a", 0.8), _node("b", 0.4)]
+    file = [_node("c", 0.9)]
+    fused = fuse_results(
+        code, file, mode="relative_score", code_weight=1.0, file_weight=2.0, rrf_k=60
+    )
+    ids = [n.node.node_id for n in fused]
+    assert ids == ["c", "a", "b"]
+
+
+def test_rrf_fusion_sorting() -> None:
+    """Reciprocal rank fusion should rescore using ranks."""
+
+    code = [_node("a", 0.5), _node("b", 0.4)]
+    file = [_node("c", 0.3)]
+    fused = fuse_results(code, file, mode="rrf", code_weight=1.0, file_weight=2.0, rrf_k=0)
+    ids = [n.node.node_id for n in fused]
+    assert ids == ["c", "a", "b"]


### PR DESCRIPTION
## Summary
- Rescore and fuse code and file retrieval results using configurable modes including RRF
- Expose weighting and RRF parameters in retrieval configuration
- Add tests validating result fusion and ordering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe5106f8083209e5918c7411db2ba