### PR TITLE
Add directory card indexing and retrieval

### DIFF
--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -33,3 +33,4 @@ def test_facade_vector_store_names(tmp_path):
     facade = LlamaIndexFacade(cfg, qdrant, initialize=False)
     assert facade.code_vs().collection_name.endswith("code_nodes")
     assert facade.file_vs().collection_name.endswith("file_cards")
+    assert facade.dir_vs().collection_name.endswith("dir_cards")


### PR DESCRIPTION
## Summary
- generate and upsert directory cards using dir_card prompt
- expose directory vector store in retriever and fuse with code and file results
- test directory card indexing and search

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0792fa11083209ea14b82a5c68089