### PR TITLE
Store OpenAI HTTP clients and ensure shutdown cleanup

### DIFF
--- a/rag_service/openai_utils.py
+++ b/rag_service/openai_utils.py
@@ -11,9 +11,17 @@ from .config import AppConfig
 
 logger = logging.getLogger(__name__)
 
+EMBEDDINGS_CLIENT: Client | None = None
+GENERATOR_CLIENT: Client | None = None
+
 
 def init_llamaindex_clients(cfg: AppConfig) -> None:
-    """Initialize LlamaIndex global settings with OpenAI clients."""
+    """Initialize LlamaIndex global settings with OpenAI clients.
+
+    The created HTTP clients are stored globally for graceful shutdown.
+    """
+
+    global EMBEDDINGS_CLIENT, GENERATOR_CLIENT
 
     def get_key(c):
         api_key = c.api_key
@@ -27,15 +35,33 @@ def init_llamaindex_clients(cfg: AppConfig) -> None:
             logger.warning("SSL verification disabled for OpenAI client %s", c.model)
         return http_client
 
+    EMBEDDINGS_CLIENT = get_http_client(cfg.openai.embeddings)
     Settings.embed_model = OpenAIEmbedding(
         model=cfg.openai.embeddings.model,
         api_base=cfg.openai.embeddings.base_url,
         api_key=get_key(cfg.openai.embeddings),
-        http_client=get_http_client(cfg.openai.embeddings)
+        http_client=EMBEDDINGS_CLIENT,
     )
+
+    GENERATOR_CLIENT = get_http_client(cfg.openai.generator)
     Settings.llm = OpenAI(
         model=cfg.openai.generator.model,
         api_base=cfg.openai.generator.base_url,
         api_key=get_key(cfg.openai.generator),
-        http_client=get_http_client(cfg.openai.generator)
+        http_client=GENERATOR_CLIENT,
     )
+
+
+def close_llamaindex_clients() -> None:
+    """Close global HTTP clients used by LlamaIndex.
+
+    When ``LlamaIndexFacade`` is used outside FastAPI, this function should
+    be called manually to release HTTP resources.
+    """
+
+    global EMBEDDINGS_CLIENT, GENERATOR_CLIENT
+    for client in (EMBEDDINGS_CLIENT, GENERATOR_CLIENT):
+        if client is not None:
+            client.close()
+    EMBEDDINGS_CLIENT = None
+    GENERATOR_CLIENT = None


### PR DESCRIPTION
## Summary
- keep embedding and generator HTTP clients in global variables
- close OpenAI clients during FastAPI shutdown
- test client storage and closing behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0860cf95c8320bd85895705c79dfb