### PR TITLE
Implement query expansion for retrieval

### DIFF
--- a/config.json
+++ b/config.json
@@ -69,7 +69,8 @@
       "fusion_mode": "relative_score",
       "code_weight": 1.0,
       "file_weight": 1.0,
-      "rrf_k": 60
+      "rrf_k": 60,
+      "max_expansions": 2
     }
   },
   "http": {

--- a/prompts/query_expander.md
+++ b/prompts/query_expander.md
@@ -1,0 +1,4 @@
+You are an expert at paraphrasing search queries.
+Generate up to {n} alternative phrasings that preserve the original meaning.
+Return a JSON object with a single key "queries" containing the list of paraphrases.
+User query: {query}

--- a/rag_service/config.py
+++ b/rag_service/config.py
@@ -59,6 +59,7 @@ class RetrievalConfig(BaseModel):
     code_weight: float = 1.0
     file_weight: float = 1.0
     rrf_k: int = 60
+    max_expansions: int = 2
 
 
 class LlamaIndexConfig(BaseModel):

--- a/rag_service/retriever.py
+++ b/rag_service/retriever.py
@@ -8,7 +8,7 @@ from qdrant_client import QdrantClient
 
 from .config import AppConfig
 from .llama_facade import LlamaIndexFacade
-from .query_rewriter import rewrite_for_collections
+from .query_rewriter import expand_queries, rewrite_for_collections
 
 
 def _relative_rescore(nodes: Sequence[NodeWithScore], weight: float) -> List[NodeWithScore]:
@@ -80,15 +80,24 @@ def build_query_engine(cfg: AppConfig, qdrant: QdrantClient, llama: LlamaIndexFa
     file_weight = getattr(cfg.llamaindex.retrieval, "file_weight", 1.0)
     dir_weight = getattr(cfg.llamaindex.retrieval, "dir_weight", 1.0)
     rrf_k = getattr(cfg.llamaindex.retrieval, "rrf_k", 60)
+    max_expansions = getattr(cfg.llamaindex.retrieval, "max_expansions", 0)
 
     class SimpleRetriever:
         def retrieve(self, query: str):
-            code_q, file_q, dir_q = rewrite_for_collections(
-                query, cfg.openai.query_rewriter
+            queries = [query]
+            queries += expand_queries(
+                query, cfg.openai.query_rewriter, max_expansions
             )
-            code_nodes = code_ret.retrieve(code_q)
-            file_nodes = file_ret.retrieve(file_q)
-            dir_nodes = dir_ret.retrieve(dir_q)
+            code_nodes: List[NodeWithScore] = []
+            file_nodes: List[NodeWithScore] = []
+            dir_nodes: List[NodeWithScore] = []
+            for q in queries:
+                code_q, file_q, dir_q = rewrite_for_collections(
+                    q, cfg.openai.query_rewriter
+                )
+                code_nodes.extend(code_ret.retrieve(code_q))
+                file_nodes.extend(file_ret.retrieve(file_q))
+                dir_nodes.extend(dir_ret.retrieve(dir_q))
             return fuse_results(
                 code_nodes,
                 file_nodes,

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from rag_service.query_rewriter import rewrite_for_collections
+from rag_service.query_rewriter import expand_queries, rewrite_for_collections
 
 
 class DummyLLM:
@@ -21,4 +21,21 @@ def test_rewrite_for_collections(monkeypatch) -> None:
     )
     code_q, file_q, dir_q = rewrite_for_collections("query", cfg=object())
     assert (code_q, file_q, dir_q) == ("c", "f", "d")
+
+
+def test_expand_queries(monkeypatch) -> None:
+    """The function should return alternative queries."""
+
+    class DummyLLM2:
+        def with_structured_output(self, model):  # pragma: no cover - simple stub
+            def _call(_):
+                return SimpleNamespace(queries=["a", "b", "c"])
+
+            return _call
+
+    monkeypatch.setattr(
+        "rag_service.query_rewriter._build_llm", lambda cfg: DummyLLM2()
+    )
+    res = expand_queries("query", cfg=object(), max_expansions=2)
+    assert res == ["a", "b"]
 

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -45,6 +45,7 @@ def test_simple_retriever_uses_query_rewriter(monkeypatch) -> None:
         file_weight=1.0,
         dir_weight=1.0,
         rrf_k=60,
+        max_expansions=2,
     )
     query_rewriter_cfg = SimpleNamespace(
         model="m",
@@ -90,13 +91,16 @@ def test_simple_retriever_uses_query_rewriter(monkeypatch) -> None:
     monkeypatch.setattr(
         "rag_service.retriever.VectorStoreIndex.from_vector_store", from_vs
     )
+    def _rewrite(q, cfg=None):
+        return (f"{q}c", f"{q}f", f"{q}d")
+
+    monkeypatch.setattr("rag_service.retriever.rewrite_for_collections", _rewrite)
     monkeypatch.setattr(
-        "rag_service.retriever.rewrite_for_collections",
-        lambda q, cfg=None: ("qc", "qf", "qd"),
+        "rag_service.retriever.expand_queries", lambda q, cfg, n: ["alt1", "alt2"]
     )
 
     retriever = build_query_engine(cfg, qdrant=None, llama=llama)
     retriever.retrieve("orig")
-    assert code_ret.queries == ["qc"]
-    assert file_ret.queries == ["qf"]
-    assert dir_ret.queries == ["qd"]
+    assert code_ret.queries == ["origc", "alt1c", "alt2c"]
+    assert file_ret.queries == ["origf", "alt1f", "alt2f"]
+    assert dir_ret.queries == ["origd", "alt1d", "alt2d"]


### PR DESCRIPTION
## Summary
- add `expand_queries` LLM helper for generating paraphrases
- search over paraphrased queries and fuse results
- allow limiting expansions via `llamaindex.retrieval.max_expansions`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0967cf3f48320839349717e2d4364