### PR TITLE
Add Swift language support

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "indexing": {
-    "include_extensions": [".kt", ".java"],
+    "include_extensions": [".kt", ".java", ".swift"],
     "blacklist": [
       "*/build/*",
       "*/.git/*",
@@ -17,7 +17,8 @@
     "max_chars": 2000,
     "languages": {
       ".kt": "kotlin",
-      ".java": "java"
+      ".java": "java",
+      ".swift": "swift"
     }
   },
   "openai": {

--- a/rag_service/interface_extractor.py
+++ b/rag_service/interface_extractor.py
@@ -17,6 +17,10 @@ PUBLIC_NODE_TYPES = {
     "class_definition",
     "class_declaration",
     "interface_declaration",
+    "protocol_declaration",
+    "protocol_function_declaration",
+    "property_declaration",
+    "extension_declaration",
     "object_declaration",
     "struct_declaration",
     "struct_item",
@@ -53,7 +57,7 @@ def _is_public(name: str, signature: str, node: Node, lang: str) -> bool:
     if name.startswith("_") or name.startswith("#"):
         return False
     lower = signature.lower()
-    if any(mod in lower for mod in ("private", "protected", "internal")):
+    if any(mod in lower for mod in ("private", "protected", "internal", "fileprivate")):
         return False
     if lang == "java":
         if "public" not in lower:
@@ -66,6 +70,14 @@ def _is_public(name: str, signature: str, node: Node, lang: str) -> bool:
                 ancestor = ancestor.parent
             if not found_interface:
                 return False
+    if lang == "swift":
+        if "public" not in lower and "open" not in lower:
+            ancestor = node.parent
+            while ancestor is not None:
+                if ancestor.type == "protocol_declaration":
+                    return True
+                ancestor = ancestor.parent
+            return False
     if lang == "rust":
         if not lower.startswith("pub"):
             return False

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -198,6 +198,41 @@ LANG_CASES = {
         ],
         "unexpected": ["privateStruct", "privateFunc"],
     },
+    "swift": {
+        "ext": "swift",
+        "code": (
+            "public protocol Sample {\n"
+            "    func protoFunc()\n"
+            "    private func hidden()\n"
+            "}\n"
+            "public class Example {\n"
+            "    public func publicMethod() {}\n"
+            "    internal func internalMethod() {}\n"
+            "    private func privateMethod() {}\n"
+            "}\n"
+            "public struct MyStruct {\n"
+            "    public var field: Int\n"
+            "    var hidden: Int\n"
+            "}\n"
+            "public func topLevel() {}\n"
+            "func internalFunc() {}\n"
+        ),
+        "expected": [
+            "public protocol Sample { [1:4]",
+            "func protoFunc() [2:2]",
+            "public class Example { [5:9]",
+            "public func publicMethod() { [6:6]",
+            "public struct MyStruct { [10:13]",
+            "public var field: [11:11]",
+            "public func topLevel() { [14:14]",
+        ],
+        "unexpected": [
+            "hidden",
+            "internalMethod",
+            "privateMethod",
+            "internalFunc",
+        ],
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- support Swift parsing in interface extractor with protocol and property handling
- include `.swift` in default config for indexing and AST language mapping
- test Swift interface extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a5fa5b948320bfe4c71662d6ccd6