### PR TITLE
Support path-derived Qdrant collections

### DIFF
--- a/config.json
+++ b/config.json
@@ -55,7 +55,6 @@
   },
   "qdrant": {
     "url": "http://localhost:6333",
-    "collection_prefix": "codrag_",
     "distance": "Cosine",
     "prefer_grpc": false
   },

--- a/rag_service/collection_utils.py
+++ b/rag_service/collection_utils.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+def collection_prefix_from_path(path: str | Path) -> str:
+    """Return a Qdrant collection prefix derived from ``path``.
+
+    The prefix is built by joining sanitized path parts with underscores and
+    appending a trailing underscore. For example, ``/home/user`` becomes
+    ``home_user_``.
+    """
+    p = Path(path)
+    parts = [re.sub(r"[^0-9A-Za-z]+", "_", part).strip("_") for part in p.parts]
+    parts = [part for part in parts if part]
+    return ("_".join(parts) + "_") if parts else ""

--- a/rag_service/config.py
+++ b/rag_service/config.py
@@ -45,7 +45,6 @@ class PromptsConfig(BaseModel):
 
 class QdrantConfig(BaseModel):
     url: str = "http://localhost:6333"
-    collection_prefix: str = ""
     distance: str = "Cosine"
     prefer_grpc: bool = False
 

--- a/rag_service/llama_facade.py
+++ b/rag_service/llama_facade.py
@@ -23,17 +23,23 @@ class LlamaIndexFacade:
     def embed_model(self):
         return Settings.embed_model
 
-    def code_vs(self) -> QdrantVectorStore:
+    def code_vs(self, collection_prefix: str) -> QdrantVectorStore:
+        """Return vector store for code nodes using ``collection_prefix``."""
+
         return QdrantVectorStore(
-            client=self.qdrant, collection_name=f"{self.cfg.qdrant.collection_prefix}code_nodes"
+            client=self.qdrant, collection_name=f"{collection_prefix}code_nodes"
         )
 
-    def file_vs(self) -> QdrantVectorStore:
+    def file_vs(self, collection_prefix: str) -> QdrantVectorStore:
+        """Return vector store for file cards using ``collection_prefix``."""
+
         return QdrantVectorStore(
-            client=self.qdrant, collection_name=f"{self.cfg.qdrant.collection_prefix}file_cards"
+            client=self.qdrant, collection_name=f"{collection_prefix}file_cards"
         )
 
-    def dir_vs(self) -> QdrantVectorStore:
+    def dir_vs(self, collection_prefix: str) -> QdrantVectorStore:
+        """Return vector store for directory cards using ``collection_prefix``."""
+
         return QdrantVectorStore(
-            client=self.qdrant, collection_name=f"{self.cfg.qdrant.collection_prefix}dir_cards"
+            client=self.qdrant, collection_name=f"{collection_prefix}dir_cards"
         )

--- a/rag_service/retriever.py
+++ b/rag_service/retriever.py
@@ -57,13 +57,20 @@ def fuse_results(
         rescored += _relative_rescore(dir_nodes, dir_weight)
     return sorted(rescored, key=lambda n: n.score, reverse=True)
 
-def build_query_engine(cfg: AppConfig, qdrant: QdrantClient, llama: LlamaIndexFacade | None = None):
+def build_query_engine(
+    cfg: AppConfig,
+    qdrant: QdrantClient,
+    llama: LlamaIndexFacade | None = None,
+    collection_prefix: str = "",
+):
     """Build a simple retriever combining code, file and directory indexes."""
 
     llama = llama or LlamaIndexFacade(cfg, qdrant)
-    code_vs = llama.code_vs()
-    file_vs = llama.file_vs()
-    dir_vs = llama.dir_vs() if cfg.features.process_directories else None
+    code_vs = llama.code_vs(collection_prefix)
+    file_vs = llama.file_vs(collection_prefix)
+    dir_vs = (
+        llama.dir_vs(collection_prefix) if cfg.features.process_directories else None
+    )
 
     code_ret = VectorStoreIndex.from_vector_store(code_vs).as_retriever(
         similarity_top_k=cfg.llamaindex.retrieval.code_nodes_top_k

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -31,6 +31,7 @@ def test_facade_vector_store_names(tmp_path):
     Settings.embed_model = DummyEmbedding()
     Settings.llm = MockLLM()
     facade = LlamaIndexFacade(cfg, qdrant, initialize=False)
-    assert facade.code_vs().collection_name.endswith("code_nodes")
-    assert facade.file_vs().collection_name.endswith("file_cards")
-    assert facade.dir_vs().collection_name.endswith("dir_cards")
+    prefix = "demo_"
+    assert facade.code_vs(prefix).collection_name.endswith("code_nodes")
+    assert facade.file_vs(prefix).collection_name.endswith("file_cards")
+    assert facade.dir_vs(prefix).collection_name.endswith("dir_cards")

--- a/tests/test_file_path_prefix.py
+++ b/tests/test_file_path_prefix.py
@@ -34,7 +34,7 @@ def test_file_path_prefix_in_results(tmp_path: Path, monkeypatch: MonkeyPatch) -
         def retrieve(self, q: str):  # type: ignore[override]
             return results
 
-    def fake_build_query_engine(cfg, qdrant, llama):  # type: ignore[unused-argument]
+    def fake_build_query_engine(cfg, qdrant, llama, collection_prefix):  # type: ignore[unused-argument]
         return Retriever()
 
     class ScrollPoint:
@@ -51,14 +51,14 @@ def test_file_path_prefix_in_results(tmp_path: Path, monkeypatch: MonkeyPatch) -
         "Cfg",
         (),
         {
-            "qdrant": type("Q", (), {"collection_prefix": ""})(),
+            "qdrant": object(),
             "features": type("F", (), {"file_path_prefix": "/prefix/"})(),
         },
     )()
     main.QDRANT = FakeQdrant()
     main.LLAMA = object()
 
-    resp = main.query_endpoint(main.QueryRequest(q="test"))
+    resp = main.query_endpoint(main.QueryRequest(root_path=str(tmp_path), q="test"))
     assert all(
         item["metadata"].get("file_path", "").startswith("/prefix/") for item in resp["items"]
     )

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -11,6 +11,7 @@ from rag_service.config import AppConfig
 from rag_service.indexer import index_path
 from rag_service.llama_facade import LlamaIndexFacade
 from rag_service.retriever import build_query_engine
+from rag_service.collection_utils import collection_prefix_from_path
 
 
 class DummyEmbedding(BaseEmbedding):
@@ -58,7 +59,8 @@ def test_index_and_query(tmp_path):
     assert stats.code_nodes_upserted > 0
     assert stats.dir_cards_upserted > 0
 
-    qe = build_query_engine(cfg, qdrant, llama)
+    prefix = collection_prefix_from_path(src)
+    qe = build_query_engine(cfg, qdrant, llama, prefix)
     res = qe.retrieve("Foo")
     assert any(n.node.metadata.get("type") == "dir_card" for n in res)
 
@@ -77,7 +79,8 @@ def test_directories_skipped_by_default(tmp_path):
     stats = index_path(src, cfg, qdrant, llama)
     assert stats.dir_cards_upserted == 0
 
-    qe = build_query_engine(cfg, qdrant, llama)
+    prefix = collection_prefix_from_path(src)
+    qe = build_query_engine(cfg, qdrant, llama, prefix)
     res = qe.retrieve("Foo")
     assert all(n.node.metadata.get("type") != "dir_card" for n in res)
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -260,13 +260,15 @@ def test_query_endpoint_interfaces(tmp_path: Path, monkeypatch: MonkeyPatch) -> 
         def retrieve(self, q: str) -> list[Result]:
             return [Result({"file_path": str(fp), "lang": "python"})]
 
-    def fake_build_query_engine(cfg, qdrant, llama):
+    def fake_build_query_engine(cfg, qdrant, llama, collection_prefix):
         return Retriever()
 
     monkeypatch.setattr(main, "build_query_engine", fake_build_query_engine)
-    main.CONFIG = object()
+    main.CONFIG = type("Cfg", (), {"features": type("F", (), {})(), "qdrant": object()})()
     main.QDRANT = object()
     main.LLAMA = object()
 
-    resp = main.query_endpoint(main.QueryRequest(q="test", interfaces=True))
+    resp = main.query_endpoint(
+        main.QueryRequest(root_path=str(tmp_path), q="test", interfaces=True)
+    )
     assert resp["items"][0]["interfaces"] == ["def foo(): [1:2]"]

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -77,9 +77,9 @@ def test_simple_retriever_uses_query_rewriter(monkeypatch) -> None:
     file_vs = object()
     dir_vs = object()
     llama = SimpleNamespace(
-        code_vs=lambda: code_vs,
-        file_vs=lambda: file_vs,
-        dir_vs=lambda: dir_vs,
+        code_vs=lambda prefix: code_vs,
+        file_vs=lambda prefix: file_vs,
+        dir_vs=lambda prefix: dir_vs,
     )
 
     def from_vs(vs):  # type: ignore[override]
@@ -100,7 +100,7 @@ def test_simple_retriever_uses_query_rewriter(monkeypatch) -> None:
         "rag_service.retriever.expand_queries", lambda q, cfg, n: ["alt1", "alt2"]
     )
 
-    retriever = build_query_engine(cfg, qdrant=None, llama=llama)
+    retriever = build_query_engine(cfg, qdrant=None, llama=llama, collection_prefix="test_")
     retriever.retrieve("orig")
     assert code_ret.queries == ["origc", "alt1c", "alt2c"]
     assert file_ret.queries == ["origf", "alt1f", "alt2f"]
@@ -151,9 +151,9 @@ def test_retriever_skips_directories_when_flag_disabled(monkeypatch) -> None:
     file_vs = object()
     dir_vs = object()
     llama = SimpleNamespace(
-        code_vs=lambda: code_vs,
-        file_vs=lambda: file_vs,
-        dir_vs=lambda: dir_vs,
+        code_vs=lambda prefix: code_vs,
+        file_vs=lambda prefix: file_vs,
+        dir_vs=lambda prefix: dir_vs,
     )
 
     def from_vs(vs):  # type: ignore[override]
@@ -174,7 +174,7 @@ def test_retriever_skips_directories_when_flag_disabled(monkeypatch) -> None:
         "rag_service.retriever.expand_queries", lambda q, cfg, n: ["alt1", "alt2"]
     )
 
-    retriever = build_query_engine(cfg, qdrant=None, llama=llama)
+    retriever = build_query_engine(cfg, qdrant=None, llama=llama, collection_prefix="test_")
     retriever.retrieve("orig")
     assert code_ret.queries == ["origc", "alt1c", "alt2c"]
     assert file_ret.queries == ["origf", "alt1f", "alt2f"]


### PR DESCRIPTION
## Summary
- derive collection prefixes from indexed path
- scope query engine and collections to the provided path
- expose root path in query requests and remove config-based prefixes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0a7158c6c8320a0d855ec5dd3f03d