### PR TITLE
Add optional LLM request/response logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - CONFIG_PATH=/app/config.json
       - OPENAI_API_KEY_EMB=${OPENAI_API_KEY_EMB}
       - OPENAI_API_KEY_GEN=${OPENAI_API_KEY_GEN}
+      - LLM_LOGGING=${LLM_LOGGING}
     volumes:
       - ./config.json:/app/config.json:ro
       - ./prompts:/app/prompts:ro

--- a/rag_service/langchain_logging.py
+++ b/rag_service/langchain_logging.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""LangChain callback handler for logging LLM interactions."""
+
+import logging
+from typing import Any, Dict, List
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.outputs import LLMResult
+
+
+class LangChainLogHandler(BaseCallbackHandler):
+    """Log prompts and responses for LangChain LLM calls."""
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__)
+
+    def on_llm_start(self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any) -> None:
+        """Log prompts sent to the LLM."""
+        for prompt in prompts:
+            self.logger.info("LLM request: %s", prompt)
+
+    def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
+        """Log responses returned by the LLM."""
+        for generations in response.generations:
+            for gen in generations:
+                self.logger.info("LLM response: %s", gen.text)

--- a/rag_service/openai_utils.py
+++ b/rag_service/openai_utils.py
@@ -6,6 +6,7 @@ from httpx import Client
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai_like import OpenAILike
 from llama_index.core import Settings
+from llama_index.core.callbacks import CallbackManager, LlamaDebugHandler
 
 from .config import AppConfig, OpenAIClientConfig
 
@@ -55,6 +56,10 @@ def init_llamaindex_clients(cfg: AppConfig) -> None:
         http_client=GENERATOR_CLIENT,
         is_chat_model=True,
     )
+
+    if os.getenv("LLM_LOGGING"):
+        Settings.callback_manager = CallbackManager([LlamaDebugHandler()])
+        logging.getLogger("llama_index").setLevel(logging.DEBUG)
 
 
 def close_llamaindex_clients() -> None:

--- a/rag_service/query_rewriter.py
+++ b/rag_service/query_rewriter.py
@@ -13,6 +13,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
 from .config import OpenAIClientConfig
+from .langchain_logging import LangChainLogHandler
 
 
 _PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "query_rewriter.md"
@@ -51,12 +52,14 @@ def _build_llm(cfg: OpenAIClientConfig | None) -> BaseChatModel | None:
     if not api_key:
         return None
     http_client = Client(verify=cfg.verify_ssl, timeout=cfg.timeout_sec)
+    callbacks = [LangChainLogHandler()] if os.getenv("LLM_LOGGING") else None
     return ChatOpenAI(
         model=cfg.model,
         base_url=cfg.base_url,
         api_key=api_key,
         max_retries=cfg.retries,
         http_client=http_client,
+        callbacks=callbacks,
     )
 
 


### PR DESCRIPTION
## Summary
- log LangChain prompts and responses when `LLM_LOGGING` env is set
- enable LlamaIndex debug callbacks under the same flag
- support env flag in docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1c22a1ad483208a78798cba540bb5