### PR TITLE
Add optional cross-encoder reranker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ pytest
 uvicorn rag_service.main:app --reload
 ```
 
+## Reranking
+
+To re-order retrieval results with a cross-encoder model, enable the reranker in the
+configuration:
+
+```json
+{
+  "llamaindex": {
+    "use": true,
+    "retrieval": {
+      "use_reranker": true
+    }
+  }
+}
+```
+
+The reranker uses the ``cross-encoder/ms-marco-MiniLM-L-6-v2`` model from the
+``sentence-transformers`` package.
+
 ## API Usage
 
 ### Index a repository

--- a/config.json
+++ b/config.json
@@ -66,6 +66,7 @@
       "file_cards_top_k": 4,
       "dir_cards_top_k": 2,
       "fusion_mode": "relative_score",
+      "use_reranker": true,
       "code_weight": 1.0,
       "file_weight": 1.0,
       "rrf_k": 60,

--- a/rag_service/config.py
+++ b/rag_service/config.py
@@ -54,6 +54,7 @@ class RetrievalConfig(BaseModel):
     file_cards_top_k: int = 4
     dir_cards_top_k: int = 2
     fusion_mode: str = "relative_score"
+    use_reranker: bool = False
     code_weight: float = 1.0
     file_weight: float = 1.0
     rrf_k: int = 60

--- a/rag_service/retriever.py
+++ b/rag_service/retriever.py
@@ -11,6 +11,42 @@ from .llama_facade import LlamaIndexFacade
 from .query_rewriter import expand_queries, rewrite_for_collections
 
 
+class CrossEncoderReranker:
+    """Rescore nodes for a query using a cross-encoder model."""
+
+    def __init__(self, model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2") -> None:
+        """Create a reranker backed by ``model``.
+
+        The sentence-transformers package is imported lazily. If it is
+        unavailable, reranking will be skipped and a warning logged.
+        """
+
+        try:  # pragma: no cover - import error pathway
+            from sentence_transformers import CrossEncoder
+        except Exception:  # pragma: no cover - best effort warning
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "sentence-transformers not installed, reranking disabled"
+            )
+            self._encoder = None
+        else:
+            self._encoder = CrossEncoder(model)
+
+    def rerank(self, query: str, nodes: Sequence[NodeWithScore]) -> List[NodeWithScore]:
+        """Return ``nodes`` sorted by cross-encoder relevance to ``query``."""
+
+        if not nodes:
+            return []
+        if self._encoder is None:
+            return list(nodes)
+        pairs = [(query, n.node.get_content()) for n in nodes]
+        scores = self._encoder.predict(pairs)
+        for node, score in zip(nodes, scores):
+            node.score = float(score)
+        return sorted(nodes, key=lambda n: n.score, reverse=True)
+
+
 def _relative_rescore(nodes: Sequence[NodeWithScore], weight: float) -> List[NodeWithScore]:
     """Rescore nodes relative to the top score and apply ``weight``."""
 
@@ -91,6 +127,8 @@ def build_query_engine(
     dir_weight = getattr(cfg.llamaindex.retrieval, "dir_weight", 1.0)
     rrf_k = getattr(cfg.llamaindex.retrieval, "rrf_k", 60)
     max_expansions = getattr(cfg.llamaindex.retrieval, "max_expansions", 0)
+    use_reranker = getattr(cfg.llamaindex.retrieval, "use_reranker", False)
+    reranker = CrossEncoderReranker() if use_reranker else None
 
     class SimpleRetriever:
         def retrieve(self, query: str):
@@ -123,7 +161,7 @@ def build_query_engine(
                 _extend_unique(file_ret.retrieve(file_q), file_nodes)
                 if cfg.features.process_directories and dir_ret is not None:
                     _extend_unique(dir_ret.retrieve(dir_q), dir_nodes)
-            return fuse_results(
+            fused = fuse_results(
                 code_nodes,
                 file_nodes,
                 dir_nodes if cfg.features.process_directories else None,
@@ -133,5 +171,8 @@ def build_query_engine(
                 dir_weight,
                 rrf_k,
             )
+            if reranker is not None:
+                fused = reranker.rerank(query, fused)
+            return fused
 
     return SimpleRetriever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ tree_sitter==0.25.1
 tree_sitter_language_pack==0.9.0
 langchain==0.3.27
 langchain-openai==0.3.32
+sentence-transformers==3.0.1

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Sequence
 
 from llama_index.core.schema import NodeWithScore, TextNode
 
@@ -245,3 +246,75 @@ def test_simple_retriever_filters_duplicate_nodes(monkeypatch) -> None:
     results = retriever.retrieve("orig")
     ids = [n.node.node_id for n in results]
     assert ids == ["dup"]
+
+
+def test_simple_retriever_applies_reranker(monkeypatch) -> None:
+    """Nodes should be reranked when the reranker flag is enabled."""
+
+    retrieval_cfg = SimpleNamespace(
+        code_nodes_top_k=1,
+        file_cards_top_k=1,
+        dir_cards_top_k=0,
+        fusion_mode="relative_score",
+        code_weight=1.0,
+        file_weight=1.0,
+        dir_weight=1.0,
+        rrf_k=60,
+        max_expansions=0,
+        use_reranker=True,
+    )
+    query_rewriter_cfg = SimpleNamespace(
+        model="m",
+        base_url="http://localhost",
+        api_key="k",
+        verify_ssl=True,
+        timeout_sec=60,
+        retries=0,
+    )
+    cfg = SimpleNamespace(
+        llamaindex=SimpleNamespace(retrieval=retrieval_cfg),
+        openai=SimpleNamespace(query_rewriter=query_rewriter_cfg),
+        features=SimpleNamespace(process_directories=False),
+    )
+
+    code_nodes = [_node("a", 0.8), _node("b", 0.4)]
+
+    class DummyRet:
+        def retrieve(self, query: str):  # pragma: no cover - simple stub
+            return code_nodes
+
+    code_ret = DummyRet()
+    code_vs = object()
+    llama = SimpleNamespace(code_vs=lambda prefix: code_vs, file_vs=lambda prefix: code_vs)
+
+    def from_vs(vs):  # type: ignore[override]
+        class _Idx:
+            def as_retriever(self, similarity_top_k):
+                return code_ret
+
+        return _Idx()
+
+    class DummyReranker:
+        def __init__(self) -> None:
+            self.called = False
+
+        def rerank(self, query: str, nodes: Sequence[NodeWithScore]):
+            self.called = True
+            return list(reversed(nodes))
+
+    monkeypatch.setattr(
+        "rag_service.retriever.VectorStoreIndex.from_vector_store", from_vs
+    )
+    monkeypatch.setattr(
+        "rag_service.retriever.rewrite_for_collections", lambda q, cfg=None: (q, q, q)
+    )
+    monkeypatch.setattr(
+        "rag_service.retriever.expand_queries", lambda q, cfg, n: []
+    )
+    monkeypatch.setattr(
+        "rag_service.retriever.CrossEncoderReranker", DummyReranker
+    )
+
+    retriever = build_query_engine(cfg, qdrant=None, llama=llama, collection_prefix="test_")
+    results = retriever.retrieve("q")
+    assert [n.node.node_id for n in results] == ["b", "a"]


### PR DESCRIPTION
## Summary
- add `use_reranker` toggle to retrieval config
- implement `CrossEncoderReranker` and integrate with query engine
- document reranking and show config example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c50d3bb08320b2b2482a853c17d4