### PR TITLE
Normalize OpenAI embeddings for queries and index

### DIFF
--- a/rag_service/openai_utils.py
+++ b/rag_service/openai_utils.py
@@ -6,6 +6,8 @@ from httpx import Client
 from llama_index.embeddings.openai import OpenAIEmbedding
 from llama_index.llms.openai_like import OpenAILike
 from llama_index.core import Settings
+from llama_index.core.base.embeddings.base import Embedding
+import numpy as np
 
 from .config import AppConfig, OpenAIClientConfig
 
@@ -13,6 +15,43 @@ logger = logging.getLogger(__name__)
 
 EMBEDDINGS_CLIENT: Client | None = None
 GENERATOR_CLIENT: Client | None = None
+
+
+class NormalizedEmbedding(OpenAIEmbedding):
+    """Embedding model wrapper that L2‑normalizes output vectors."""
+
+    def _normalize(self, embedding: Embedding) -> Embedding:
+        """Return the L2‑normalized version of ``embedding``."""
+
+        arr = np.array(embedding, dtype=np.float32)
+        norm = float(np.linalg.norm(arr))
+        if norm == 0:
+            return embedding
+        return (arr / norm).tolist()
+
+    def get_text_embedding(self, text: str) -> Embedding:
+        """Embed ``text`` and return a normalized vector."""
+
+        embedding = super().get_text_embedding(text)
+        return self._normalize(embedding)
+
+    async def aget_text_embedding(self, text: str) -> Embedding:
+        """Asynchronously embed ``text`` and return a normalized vector."""
+
+        embedding = await super().aget_text_embedding(text)
+        return self._normalize(embedding)
+
+    def get_query_embedding(self, query: str) -> Embedding:
+        """Embed ``query`` and return a normalized vector."""
+
+        embedding = super().get_query_embedding(query)
+        return self._normalize(embedding)
+
+    async def aget_query_embedding(self, query: str) -> Embedding:
+        """Asynchronously embed ``query`` and return a normalized vector."""
+
+        embedding = await super().aget_query_embedding(query)
+        return self._normalize(embedding)
 
 
 def init_llamaindex_clients(cfg: AppConfig) -> None:
@@ -40,7 +79,7 @@ def init_llamaindex_clients(cfg: AppConfig) -> None:
         return http_client
 
     EMBEDDINGS_CLIENT = get_http_client(cfg.openai.embeddings)
-    Settings.embed_model = OpenAIEmbedding(
+    Settings.embed_model = NormalizedEmbedding(
         model=cfg.openai.embeddings.model,
         api_base=cfg.openai.embeddings.base_url,
         api_key=get_key(cfg.openai.embeddings),

--- a/rag_service/retriever.py
+++ b/rag_service/retriever.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Sequence
 
-from llama_index.core import VectorStoreIndex
+from llama_index.core import Settings, VectorStoreIndex
 from llama_index.core.schema import NodeWithScore
 from qdrant_client import QdrantClient
 
@@ -72,14 +72,20 @@ def build_query_engine(
         llama.dir_vs(collection_prefix) if cfg.features.process_directories else None
     )
 
-    code_ret = VectorStoreIndex.from_vector_store(code_vs).as_retriever(
+    code_ret = VectorStoreIndex.from_vector_store(
+        code_vs, embed_model=Settings.embed_model
+    ).as_retriever(
         similarity_top_k=cfg.llamaindex.retrieval.code_nodes_top_k
     )
-    file_ret = VectorStoreIndex.from_vector_store(file_vs).as_retriever(
+    file_ret = VectorStoreIndex.from_vector_store(
+        file_vs, embed_model=Settings.embed_model
+    ).as_retriever(
         similarity_top_k=cfg.llamaindex.retrieval.file_cards_top_k
     )
     if cfg.features.process_directories and dir_vs is not None:
-        dir_ret = VectorStoreIndex.from_vector_store(dir_vs).as_retriever(
+        dir_ret = VectorStoreIndex.from_vector_store(
+            dir_vs, embed_model=Settings.embed_model
+        ).as_retriever(
             similarity_top_k=cfg.llamaindex.retrieval.dir_cards_top_k
         )
     else:


### PR DESCRIPTION
## Summary
- add `NormalizedEmbedding` wrapper that L2 normalizes OpenAI embeddings
- use `NormalizedEmbedding` as `Settings.embed_model`
- ensure retriever uses normalized embed model for queries

## Testing
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c61d82b48320a911ed034437f0b6