### PR TITLE
Add configurable Qdrant distances for code and text

### DIFF
--- a/config.json
+++ b/config.json
@@ -56,7 +56,8 @@
   },
   "qdrant": {
     "url": "http://localhost:6333",
-    "distance": "Cosine",
+    "code_distance": "Cosine",
+    "text_distance": "Cosine",
     "prefer_grpc": false
   },
   "llamaindex": {

--- a/rag_service/config.py
+++ b/rag_service/config.py
@@ -45,7 +45,8 @@ class PromptsConfig(BaseModel):
 
 class QdrantConfig(BaseModel):
     url: str = "http://localhost:6333"
-    distance: str = "Cosine"
+    code_distance: str = "Cosine"
+    text_distance: str = "Cosine"
     prefer_grpc: bool = False
 
 

--- a/rag_service/llama_facade.py
+++ b/rag_service/llama_facade.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 from llama_index.core import Settings
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
+from qdrant_client.http import models
 
 from .config import AppConfig
 from .openai_utils import init_llamaindex_clients
+
+
+DISTANCE_MAP = {
+    "Cosine": models.Distance.COSINE,
+    "Euclid": models.Distance.EUCLID,
+    "Manhattan": models.Distance.MANHATTAN,
+}
 
 
 class LlamaIndexFacade:
@@ -16,30 +24,51 @@ class LlamaIndexFacade:
         self.qdrant = qdrant
         if initialize:
             init_llamaindex_clients(cfg)
+        self._vector_size = len(
+            Settings.embed_model.get_text_embedding("qdrant_dim_probe")
+        )
+        self._stores: dict[str, QdrantVectorStore] = {}
 
-    def llm(self):
+    def llm(self) -> object:
+        """Return the configured language model."""
+
         return Settings.llm
 
-    def embed_model(self):
+    def embed_model(self) -> object:
+        """Return the configured embedding model."""
+
         return Settings.embed_model
+
+    def _create_vs(self, name: str, distance_name: str) -> QdrantVectorStore:
+        """Create or recreate a Qdrant collection and return its vector store."""
+
+        if name not in self._stores:
+            distance = DISTANCE_MAP[distance_name]
+            self.qdrant.recreate_collection(
+                name,
+                vectors_config=models.VectorParams(
+                    size=self._vector_size, distance=distance
+                ),
+            )
+            self._stores[name] = QdrantVectorStore(
+                client=self.qdrant, collection_name=name
+            )
+        return self._stores[name]
 
     def code_vs(self, collection_prefix: str) -> QdrantVectorStore:
         """Return vector store for code nodes using ``collection_prefix``."""
 
-        return QdrantVectorStore(
-            client=self.qdrant, collection_name=f"{collection_prefix}code_nodes"
-        )
+        name = f"{collection_prefix}code_nodes"
+        return self._create_vs(name, self.cfg.qdrant.code_distance)
 
     def file_vs(self, collection_prefix: str) -> QdrantVectorStore:
         """Return vector store for file cards using ``collection_prefix``."""
 
-        return QdrantVectorStore(
-            client=self.qdrant, collection_name=f"{collection_prefix}file_cards"
-        )
+        name = f"{collection_prefix}file_cards"
+        return self._create_vs(name, self.cfg.qdrant.text_distance)
 
     def dir_vs(self, collection_prefix: str) -> QdrantVectorStore:
         """Return vector store for directory cards using ``collection_prefix``."""
 
-        return QdrantVectorStore(
-            client=self.qdrant, collection_name=f"{collection_prefix}dir_cards"
-        )
+        name = f"{collection_prefix}dir_cards"
+        return self._create_vs(name, self.cfg.qdrant.text_distance)

--- a/tests/test_facade.py
+++ b/tests/test_facade.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from qdrant_client import QdrantClient
+from qdrant_client.http import models
 from llama_index.core import Settings
 from llama_index.core.embeddings import BaseEmbedding
 from llama_index.core.llms import MockLLM
@@ -35,3 +36,34 @@ def test_facade_vector_store_names(tmp_path):
     assert facade.code_vs(prefix).collection_name.endswith("code_nodes")
     assert facade.file_vs(prefix).collection_name.endswith("file_cards")
     assert facade.dir_vs(prefix).collection_name.endswith("dir_cards")
+
+
+def test_facade_respects_distances(tmp_path):
+    """Facade should recreate collections with configured distances."""
+
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(
+        '{'
+        '"version":1,'
+        '"indexing":{},'
+        '"ast":{},'
+        '"openai":{"embeddings":{"base_url":"","model":"m","api_key":"k"},'
+        '"generator":{"base_url":"","model":"m","api_key":"k"},'
+        '"query_rewriter":{"base_url":"","model":"m","api_key":"k"}},'
+        '"prompts":{"file_card_md":"a","dir_card_md":"b"},'
+        '"qdrant":{"code_distance":"Euclid","text_distance":"Manhattan"},'
+        '"llamaindex":{}'
+        '}'
+    )
+    cfg = AppConfig.load(cfg_path)
+    qdrant = QdrantClient(location=":memory:")
+    Settings.embed_model = DummyEmbedding()
+    Settings.llm = MockLLM()
+    facade = LlamaIndexFacade(cfg, qdrant, initialize=False)
+    prefix = "demo_"
+    facade.code_vs(prefix)
+    facade.file_vs(prefix)
+    code_info = qdrant.get_collection(f"{prefix}code_nodes")
+    file_info = qdrant.get_collection(f"{prefix}file_cards")
+    assert code_info.config.params.vectors.distance == models.Distance.EUCLID
+    assert file_info.config.params.vectors.distance == models.Distance.MANHATTAN


### PR DESCRIPTION
## Summary
- Allow separate code and text distance settings in Qdrant configuration
- Recreate Qdrant collections with proper distances when obtaining vector stores
- Test Qdrant distance handling and adjust retriever tests for explicit embed model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ce7a8d7c83209e395ac584b91e19