### PR TITLE
Add repository-level prompt for indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ The reranker uses the ``cross-encoder/ms-marco-MiniLM-L-6-v2`` model from the
 
 ### Index a repository
 
+Include an optional ``repo_prompt`` to describe the project. This text is used when generating
+summaries for files and directories.
+
 ```bash
 curl -X POST http://localhost:8000/v1/index \
     -H "Content-Type: application/json" \
-    -d '{"root_path": ".", "clean": false}'
+    -d '{"root_path": ".", "clean": false, "repo_prompt": "Project context"}'
 ```
 
 ### Query indexed data

--- a/rag_service/main.py
+++ b/rag_service/main.py
@@ -28,6 +28,7 @@ QE_CONFIG_ID: int | None = None
 class IndexRequest(BaseModel):
     root_path: str
     clean: bool = False
+    repo_prompt: str | None = None
 
 
 class QueryRequest(BaseModel):
@@ -97,7 +98,13 @@ def index_endpoint(req: IndexRequest):
 
     assert CONFIG and QDRANT and LLAMA
     start = time.time()
-    stats = index_path(Path(req.root_path), CONFIG, QDRANT, LLAMA)
+    stats = index_path(
+        Path(req.root_path),
+        CONFIG,
+        QDRANT,
+        LLAMA,
+        repo_prompt=req.repo_prompt or "",
+    )
     took = int((time.time() - start) * 1000)
     return {"status": "ok", "indexed": stats.__dict__, "took_ms": took}
 


### PR DESCRIPTION
## Summary
- Allow passing a repository description prompt to the indexer
- Use the repository prompt when generating file and directory summaries
- Document new `repo_prompt` field in indexing API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8b21dac8320b86fdbf97e4971a5