### PR TITLE
Default to simple retriever and drop staged option

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,7 +80,8 @@
       "code_weight": 1.0,
       "file_weight": 1.0,
       "rrf_k": 60,
-      "max_expansions": 2
+      "max_expansions": 2,
+      "retriever": "simple"
     }
   },
   "http": {

--- a/rag_service/config.py
+++ b/rag_service/config.py
@@ -59,10 +59,12 @@ class RetrievalConfig(BaseModel):
     use_reranker: bool = False
     code_weight: float = 1.0
     file_weight: float = 1.0
+    dir_weight: float = 1.0
     rrf_k: int = 60
     max_expansions: int = 2
     use_hyde_for_code: bool = False
     hyde_docs: int = 1
+    retriever: str = "simple"
 
 
 class LlamaIndexConfig(BaseModel):

--- a/rag_service/main.py
+++ b/rag_service/main.py
@@ -44,8 +44,8 @@ def _with_file_path_prefix(metadata: dict) -> dict:
     """Return a copy of ``metadata`` with configured file path prefix applied."""
 
     assert CONFIG
-    features = getattr(CONFIG, "features", None)
-    prefix = getattr(features, "file_path_prefix", "")
+    features = CONFIG.features
+    prefix = features.file_path_prefix if hasattr(features, "file_path_prefix") else ""
     file_path = metadata.get("file_path")
     if prefix and file_path:
         return {**metadata, "file_path": prefix + file_path}

--- a/rag_service/query_metadata.py
+++ b/rag_service/query_metadata.py
@@ -121,7 +121,7 @@ def boost_file_nodes_by_metadata(
 
     boosted: List[NodeWithScore] = []
     for n in nodes:
-        payload = getattr(n.node, "metadata", {}) or {}
+        payload = n.node.metadata or {} if hasattr(n.node, "metadata") else {}
         score = float(n.score or 0.0)
 
         # Language boost

--- a/rag_service/retriever.py
+++ b/rag_service/retriever.py
@@ -1,105 +1,15 @@
 from __future__ import annotations
 
-from typing import List, Sequence
-
-from llama_index.core import Settings, VectorStoreIndex
-from llama_index.core.schema import NodeWithScore
+from llama_index.core import VectorStoreIndex  # re-exported for tests
 from qdrant_client import QdrantClient
 
 from .config import AppConfig
 from .llama_facade import LlamaIndexFacade
-from .query_rewriter import (
-    expand_queries,
-    rewrite_for_collections,
-    hyde_code_documents,
-)
-from .query_metadata import (
-    extract_file_query_metadata,
-    boost_file_nodes_by_metadata,
-)
+from .retrievers.simple import build_simple_retriever
+from .retrievers.utils import CrossEncoderReranker, fuse_results
+from .query_rewriter import expand_queries, rewrite_for_collections, hyde_code_documents
+from .query_metadata import extract_file_query_metadata, boost_file_nodes_by_metadata
 
-
-class CrossEncoderReranker:
-    """Rescore nodes for a query using a cross-encoder model."""
-
-    def __init__(self, model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2") -> None:
-        """Create a reranker backed by ``model``.
-
-        The sentence-transformers package is imported lazily. If it is
-        unavailable, reranking will be skipped and a warning logged.
-        """
-
-        try:  # pragma: no cover - import error pathway
-            from sentence_transformers import CrossEncoder
-        except Exception:  # pragma: no cover - best effort warning
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "sentence-transformers not installed, reranking disabled"
-            )
-            self._encoder = None
-        else:
-            self._encoder = CrossEncoder(model)
-
-    def rerank(self, query: str, nodes: Sequence[NodeWithScore]) -> List[NodeWithScore]:
-        """Return ``nodes`` sorted by cross-encoder relevance to ``query``."""
-
-        if not nodes:
-            return []
-        if self._encoder is None:
-            return list(nodes)
-        pairs = [(query, n.node.get_content()) for n in nodes]
-        scores = self._encoder.predict(pairs)
-        for node, score in zip(nodes, scores):
-            node.score = float(score)
-        return sorted(nodes, key=lambda n: n.score, reverse=True)
-
-
-def _relative_rescore(nodes: Sequence[NodeWithScore], weight: float) -> List[NodeWithScore]:
-    """Rescore nodes relative to the top score and apply ``weight``."""
-
-    if not nodes:
-        return []
-    top = nodes[0].score or 1.0
-    for node in nodes:
-        node.score = weight * (node.score / top)
-    return list(nodes)
-
-
-def _rrf_rescore(
-    nodes: Sequence[NodeWithScore], weight: float, k: int
-) -> List[NodeWithScore]:
-    """Apply reciprocal rank fusion to ``nodes`` with ``weight``."""
-
-    rescored: List[NodeWithScore] = []
-    for idx, node in enumerate(nodes, start=1):
-        node.score = weight / (k + idx)
-        rescored.append(node)
-    return rescored
-
-
-def fuse_results(
-    code_nodes: Sequence[NodeWithScore],
-    file_nodes: Sequence[NodeWithScore],
-    dir_nodes: Sequence[NodeWithScore] | None = None,
-    mode: str = "relative_score",
-    code_weight: float = 1.0,
-    file_weight: float = 1.0,
-    dir_weight: float = 1.0,
-    rrf_k: int = 60,
-) -> List[NodeWithScore]:
-    """Fuse code, file and directory retrieval results according to ``mode``."""
-
-    dir_nodes = dir_nodes or []
-    if mode == "rrf":
-        rescored = _rrf_rescore(code_nodes, code_weight, rrf_k)
-        rescored += _rrf_rescore(file_nodes, file_weight, rrf_k)
-        rescored += _rrf_rescore(dir_nodes, dir_weight, rrf_k)
-    else:
-        rescored = _relative_rescore(code_nodes, code_weight)
-        rescored += _relative_rescore(file_nodes, file_weight)
-        rescored += _relative_rescore(dir_nodes, dir_weight)
-    return sorted(rescored, key=lambda n: n.score, reverse=True)
 
 def build_query_engine(
     cfg: AppConfig,
@@ -107,110 +17,7 @@ def build_query_engine(
     llama: LlamaIndexFacade | None = None,
     collection_prefix: str = "",
 ):
-    """Build a simple retriever combining code, file and directory indexes."""
+    """Return a retriever instance according to configuration."""
 
-    llama = llama or LlamaIndexFacade(cfg, qdrant)
-    code_vs = llama.code_vs(collection_prefix)
-    file_vs = llama.file_vs(collection_prefix)
-    dir_vs = (
-        llama.dir_vs(collection_prefix) if cfg.features.process_directories else None
-    )
+    return build_simple_retriever(cfg, qdrant, llama, collection_prefix)
 
-    code_ret = VectorStoreIndex.from_vector_store(
-        code_vs, embed_model=Settings.code_embed_model
-    ).as_retriever(
-        similarity_top_k=cfg.llamaindex.retrieval.code_nodes_top_k
-    )
-    file_ret = VectorStoreIndex.from_vector_store(
-        file_vs, embed_model=Settings.text_embed_model
-    ).as_retriever(
-        similarity_top_k=cfg.llamaindex.retrieval.file_cards_top_k
-    )
-    if cfg.features.process_directories and dir_vs is not None:
-        dir_ret = VectorStoreIndex.from_vector_store(
-            dir_vs, embed_model=Settings.text_embed_model
-        ).as_retriever(
-            similarity_top_k=cfg.llamaindex.retrieval.dir_cards_top_k
-        )
-    else:
-        dir_ret = None
-
-    fusion_mode = cfg.llamaindex.retrieval.fusion_mode
-    code_weight = getattr(cfg.llamaindex.retrieval, "code_weight", 1.0)
-    file_weight = getattr(cfg.llamaindex.retrieval, "file_weight", 1.0)
-    dir_weight = getattr(cfg.llamaindex.retrieval, "dir_weight", 1.0)
-    rrf_k = getattr(cfg.llamaindex.retrieval, "rrf_k", 60)
-    max_expansions = getattr(cfg.llamaindex.retrieval, "max_expansions", 0)
-    use_reranker = getattr(cfg.llamaindex.retrieval, "use_reranker", False)
-    reranker = CrossEncoderReranker() if use_reranker else None
-
-    class SimpleRetriever:
-        def __init__(self) -> None:
-            self._hyde_system_prompt: str = ""
-
-        def set_runtime_options(self, hyde_system_prompt: str = "") -> None:
-            """Set per-request options such as HyDE system prompt."""
-
-            self._hyde_system_prompt = hyde_system_prompt or ""
-
-        def retrieve(self, query: str):
-            queries = [query]
-            queries += expand_queries(
-                query, cfg.openai.query_rewriter, max_expansions
-            )
-            code_nodes: List[NodeWithScore] = []
-            file_nodes: List[NodeWithScore] = []
-            dir_nodes: List[NodeWithScore] = []
-            seen: set[str] = set()
-
-            def _extend_unique(
-                nodes: Sequence[NodeWithScore], dest: List[NodeWithScore]
-            ) -> None:
-                """Append ``nodes`` to ``dest`` if their IDs are unseen."""
-
-                for node in nodes:
-                    node_id = node.node.node_id
-                    if node_id in seen:
-                        continue
-                    seen.add(node_id)
-                    dest.append(node)
-
-            use_hyde = getattr(cfg.llamaindex.retrieval, "use_hyde_for_code", False)
-            hyde_n = max(0, int(getattr(cfg.llamaindex.retrieval, "hyde_docs", 1)))
-
-            # Extract metadata once from the original query for use with file-card results
-            file_query_meta = extract_file_query_metadata(query, cfg.openai.query_rewriter)
-
-            for q in queries:
-                code_q, file_q, dir_q = rewrite_for_collections(
-                    q, cfg.openai.query_rewriter
-                )
-                if use_hyde and hyde_n > 0:
-                    drafts = hyde_code_documents(
-                        code_q, cfg.openai.generator, n=hyde_n, system_prompt=self._hyde_system_prompt
-                    )
-                    for d in drafts:
-                        _extend_unique(code_ret.retrieve(d), code_nodes)
-                # Also query with the rewritten code query to keep recall high.
-                _extend_unique(code_ret.retrieve(code_q), code_nodes)
-                _extend_unique(file_ret.retrieve(file_q), file_nodes)
-                if cfg.features.process_directories and dir_ret is not None:
-                    _extend_unique(dir_ret.retrieve(dir_q), dir_nodes)
-            # Soft-boost file results using extracted metadata before fusion
-            file_nodes = boost_file_nodes_by_metadata(file_nodes, file_query_meta)
-
-            fused = fuse_results(
-                code_nodes,
-                file_nodes,
-                dir_nodes if cfg.features.process_directories else None,
-                fusion_mode,
-                code_weight,
-                file_weight,
-                dir_weight,
-                rrf_k,
-            )
-            if reranker is not None:
-                fused = reranker.rerank(query, fused)
-            return fused
-
-    return SimpleRetriever()

--- a/rag_service/retrievers/simple.py
+++ b/rag_service/retrievers/simple.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from llama_index.core import Settings, VectorStoreIndex
+from llama_index.core.schema import NodeWithScore
+from qdrant_client import QdrantClient
+
+from ..config import AppConfig, RetrievalConfig
+from ..llama_facade import LlamaIndexFacade
+from .utils import CrossEncoderReranker, fuse_results
+
+
+class SimpleRetriever:
+    """Basic retriever combining code, file and directory indexes."""
+
+    def __init__(
+        self,
+        cfg: AppConfig,
+        qdrant: QdrantClient,
+        llama: LlamaIndexFacade | None = None,
+        collection_prefix: str = "",
+    ) -> None:
+        self._cfg = cfg
+        self._llama = llama or LlamaIndexFacade(cfg, qdrant)
+        self._code_vs = self._llama.code_vs(collection_prefix)
+        self._file_vs = self._llama.file_vs(collection_prefix)
+        self._dir_vs = (
+            self._llama.dir_vs(collection_prefix)
+            if cfg.features.process_directories
+            else None
+        )
+        self._hyde_system_prompt: str = ""
+
+        retrieval = cfg.llamaindex.retrieval
+        if not isinstance(retrieval, RetrievalConfig):
+            retrieval = RetrievalConfig(**retrieval.__dict__)
+            cfg.llamaindex.retrieval = retrieval
+        self._retrieval = retrieval
+
+        code_model = (
+            Settings.code_embed_model if hasattr(Settings, "code_embed_model") else None
+        )
+        self._code_ret = VectorStoreIndex.from_vector_store(
+            self._code_vs, embed_model=code_model
+        ).as_retriever(
+            similarity_top_k=self._retrieval.code_nodes_top_k,
+        )
+        text_model = (
+            Settings.text_embed_model if hasattr(Settings, "text_embed_model") else None
+        )
+        self._file_ret = VectorStoreIndex.from_vector_store(
+            self._file_vs, embed_model=text_model
+        ).as_retriever(
+            similarity_top_k=self._retrieval.file_cards_top_k,
+        )
+        if cfg.features.process_directories and self._dir_vs is not None:
+            self._dir_ret = VectorStoreIndex.from_vector_store(
+                self._dir_vs, embed_model=text_model
+            ).as_retriever(
+                similarity_top_k=self._retrieval.dir_cards_top_k,
+            )
+        else:
+            self._dir_ret = None
+
+        self._fusion_mode = self._retrieval.fusion_mode
+        self._code_weight = self._retrieval.code_weight
+        self._file_weight = self._retrieval.file_weight
+        self._dir_weight = self._retrieval.dir_weight
+        self._rrf_k = self._retrieval.rrf_k
+        self._max_expansions = self._retrieval.max_expansions
+        use_reranker = self._retrieval.use_reranker
+        self._reranker = CrossEncoderReranker() if use_reranker else None
+
+    def set_runtime_options(self, hyde_system_prompt: str = "") -> None:
+        """Set per-request options such as HyDE system prompt."""
+
+        self._hyde_system_prompt = hyde_system_prompt or ""
+
+    def _extend_unique(
+        self,
+        nodes: Sequence[NodeWithScore],
+        dest: List[NodeWithScore],
+        seen: set[str],
+    ) -> None:
+        """Append ``nodes`` to ``dest`` if their IDs are unseen."""
+
+        for node in nodes:
+            node_id = node.node.node_id
+            if node_id in seen:
+                continue
+            seen.add(node_id)
+            dest.append(node)
+
+    def retrieve(self, query: str) -> List[NodeWithScore]:
+        """Retrieve relevant nodes for ``query``."""
+
+        queries = [query]
+        from .. import retriever as _r  # late import for monkeypatching
+
+        queries += _r.expand_queries(
+            query, self._cfg.openai.query_rewriter, self._max_expansions
+        )
+        code_nodes: List[NodeWithScore] = []
+        file_nodes: List[NodeWithScore] = []
+        dir_nodes: List[NodeWithScore] = []
+        seen: set[str] = set()
+
+        use_hyde = self._retrieval.use_hyde_for_code
+        hyde_n = max(0, int(self._retrieval.hyde_docs))
+
+        file_query_meta = _r.extract_file_query_metadata(
+            query, self._cfg.openai.query_rewriter
+        )
+
+        for q in queries:
+            code_q, file_q, dir_q = _r.rewrite_for_collections(
+                q, self._cfg.openai.query_rewriter
+            )
+            if use_hyde and hyde_n > 0:
+                drafts = _r.hyde_code_documents(
+                    code_q,
+                    self._cfg.openai.generator,
+                    n=hyde_n,
+                    system_prompt=self._hyde_system_prompt,
+                )
+                for d in drafts:
+                    self._extend_unique(self._code_ret.retrieve(d), code_nodes, seen)
+            self._extend_unique(self._code_ret.retrieve(code_q), code_nodes, seen)
+            self._extend_unique(self._file_ret.retrieve(file_q), file_nodes, seen)
+            if (
+                self._cfg.features.process_directories
+                and self._dir_ret is not None
+            ):
+                self._extend_unique(self._dir_ret.retrieve(dir_q), dir_nodes, seen)
+        file_nodes = _r.boost_file_nodes_by_metadata(file_nodes, file_query_meta)
+
+        fused = fuse_results(
+            code_nodes,
+            file_nodes,
+            dir_nodes if self._cfg.features.process_directories else None,
+            self._fusion_mode,
+            self._code_weight,
+            self._file_weight,
+            self._dir_weight,
+            self._rrf_k,
+        )
+        if self._reranker is not None:
+            fused = self._reranker.rerank(query, fused)
+        return fused
+
+
+def build_simple_retriever(
+    cfg: AppConfig,
+    qdrant: QdrantClient,
+    llama: LlamaIndexFacade | None = None,
+    collection_prefix: str = "",
+) -> SimpleRetriever:
+    """Build and return :class:`SimpleRetriever`."""
+
+    return SimpleRetriever(cfg, qdrant, llama, collection_prefix)

--- a/rag_service/retrievers/utils.py
+++ b/rag_service/retrievers/utils.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from llama_index.core.schema import NodeWithScore
+
+
+class CrossEncoderReranker:
+    """Rescore nodes for a query using a cross-encoder model."""
+
+    def __init__(self, model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2") -> None:
+        """Create a reranker backed by ``model``.
+
+        The sentence-transformers package is imported lazily. If it is
+        unavailable, reranking will be skipped and a warning logged.
+        """
+
+        try:  # pragma: no cover - import error pathway
+            from sentence_transformers import CrossEncoder
+        except Exception:  # pragma: no cover - best effort warning
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "sentence-transformers not installed, reranking disabled",
+            )
+            self._encoder = None
+        else:
+            self._encoder = CrossEncoder(model)
+
+    def rerank(self, query: str, nodes: Sequence[NodeWithScore]) -> List[NodeWithScore]:
+        """Return ``nodes`` sorted by cross-encoder relevance to ``query``."""
+
+        if not nodes:
+            return []
+        if self._encoder is None:
+            return list(nodes)
+        pairs = [(query, n.node.get_content()) for n in nodes]
+        scores = self._encoder.predict(pairs)
+        for node, score in zip(nodes, scores):
+            node.score = float(score)
+        return sorted(nodes, key=lambda n: n.score, reverse=True)
+
+
+def _relative_rescore(nodes: Sequence[NodeWithScore], weight: float) -> List[NodeWithScore]:
+    """Rescore nodes relative to the top score and apply ``weight``."""
+
+    if not nodes:
+        return []
+    top = nodes[0].score or 1.0
+    for node in nodes:
+        node.score = weight * (node.score / top)
+    return list(nodes)
+
+
+def _rrf_rescore(
+    nodes: Sequence[NodeWithScore], weight: float, k: int,
+) -> List[NodeWithScore]:
+    """Apply reciprocal rank fusion to ``nodes`` with ``weight``."""
+
+    rescored: List[NodeWithScore] = []
+    for idx, node in enumerate(nodes, start=1):
+        node.score = weight / (k + idx)
+        rescored.append(node)
+    return rescored
+
+
+def fuse_results(
+    code_nodes: Sequence[NodeWithScore],
+    file_nodes: Sequence[NodeWithScore],
+    dir_nodes: Sequence[NodeWithScore] | None = None,
+    mode: str = "relative_score",
+    code_weight: float = 1.0,
+    file_weight: float = 1.0,
+    dir_weight: float = 1.0,
+    rrf_k: int = 60,
+) -> List[NodeWithScore]:
+    """Fuse code, file and directory retrieval results according to ``mode``."""
+
+    dir_nodes = dir_nodes or []
+    if mode == "rrf":
+        rescored = _rrf_rescore(code_nodes, code_weight, rrf_k)
+        rescored += _rrf_rescore(file_nodes, file_weight, rrf_k)
+        rescored += _rrf_rescore(dir_nodes, dir_weight, rrf_k)
+    else:
+        rescored = _relative_rescore(code_nodes, code_weight)
+        rescored += _relative_rescore(file_nodes, file_weight)
+        rescored += _relative_rescore(dir_nodes, dir_weight)
+    return sorted(rescored, key=lambda n: n.score, reverse=True)


### PR DESCRIPTION
## Summary
- add `retriever` field in config and set default to `simple`
- drop staged retriever and always build the simple retriever
- replace dynamic `getattr` usage with typed config and `hasattr` checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b750883483208c49682bfec13501