### PR TITLE
Add web interface container for querying RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ pytest
 uvicorn rag_service.main:app --reload
 ```
 
+## Web Interface
+
+The repository includes a minimal web interface for sending queries to the RAG service.
+Launch it together with the service using Docker Compose:
+
+```bash
+docker-compose up web
+```
+
+The container is configured via environment variables:
+
+- `ROOT_PATH`: path to the indexed repository.
+- `HYDE_PROMPT_PATH`: file with the HyDE system prompt used during queries.
+
 ## Reranking
 
 To re-order retrieval results with a cross-encoder model, enable the reranker in the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,16 @@ services:
       - "8080:8080"
     depends_on:
       - qdrant
+
+  web:
+    build: ./web
+    environment:
+      - ROOT_PATH=/repo
+      - HYDE_PROMPT_PATH=/app/prompts/hyde_code.md
+      - QUERY_URL=http://rag:8080/v1/query
+    volumes:
+      - ./prompts:/app/prompts:ro
+    ports:
+      - "3000:8000"
+    depends_on:
+      - rag

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import httpx
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+app = FastAPI()
+
+templates = Jinja2Templates(directory="templates")
+
+ROOT_PATH = os.environ.get("ROOT_PATH", "")
+HYDE_PROMPT_PATH = os.environ.get("HYDE_PROMPT_PATH", "")
+QUERY_URL = os.environ.get("QUERY_URL", "http://rag:8080/v1/query")
+
+HYDE_PROMPT: str = ""
+if HYDE_PROMPT_PATH:
+    try:
+        HYDE_PROMPT = Path(HYDE_PROMPT_PATH).read_text(encoding="utf-8")
+    except OSError:
+        HYDE_PROMPT = ""
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request) -> HTMLResponse:
+    """Return the search page."""
+
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/search")
+async def search(payload: dict[str, str]) -> dict:
+    """Forward the query to the RAG service."""
+
+    query = payload.get("query", "")
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            QUERY_URL,
+            json={
+                "root_path": ROOT_PATH,
+                "q": query,
+                "hyde_system_prompt": HYDE_PROMPT,
+            },
+        )
+    return response.json()

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.112.0
+uvicorn[standard]==0.30.0
+jinja2==3.1.4
+httpx==0.27.0

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="utf-8" />
+    <title>RAG Search</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem auto; max-width: 800px; }
+        textarea { width: 100%; height: 150px; padding: 1rem; font-size: 1rem; }
+        button { margin-top: 1rem; padding: 0.5rem 1rem; font-size: 1rem; cursor: pointer; }
+        pre { background: #f5f5f5; padding: 1rem; white-space: pre-wrap; border-radius: 4px; margin-top: 1rem; }
+    </style>
+</head>
+<body>
+    <textarea id="query" placeholder="Введите запрос..."></textarea>
+    <button id="submit">Отправить</button>
+    <pre id="result"></pre>
+    <script>
+    document.getElementById('submit').onclick = async () => {
+        const q = document.getElementById('query').value;
+        const res = await fetch('/search', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: q })
+        });
+        const data = await res.json();
+        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI-based web interface for sending RAG queries with HyDE prompt
- create Docker configuration and compose service for the UI
- document web interface usage and configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3570828b08320960caf3d042023c6